### PR TITLE
changed content-type 'x-www-form-urlencoded' to valid content-type 'appl...

### DIFF
--- a/lib/middleware/accessToken.js
+++ b/lib/middleware/accessToken.js
@@ -150,7 +150,7 @@ module.exports = function accessToken(options, verify, issue) {
         return utils.encode(key) + '=' + utils.encode(params[key]);
       }).join('&');
       
-      res.setHeader('Content-Type', 'x-www-form-urlencoded');
+      res.setHeader('Content-Type', 'application/x-www-form-urlencoded');
       res.setHeader('Cache-Control', 'no-store');
       res.setHeader('Pragma', 'no-cache');
       res.end(fue);

--- a/lib/middleware/errorHandler.js
+++ b/lib/middleware/errorHandler.js
@@ -83,7 +83,7 @@ module.exports = function errorHandler(options) {
         return utils.encode(key) + '=' + utils.encode(params[key]);
       }).join('&');
       
-      res.setHeader('Content-Type', 'x-www-form-urlencoded');
+      res.setHeader('Content-Type', 'application/x-www-form-urlencoded');
       return res.end(fue);
       
     } else if (mode == 'indirect') {

--- a/lib/middleware/requestToken.js
+++ b/lib/middleware/requestToken.js
@@ -166,7 +166,7 @@ module.exports = function requestToken(options, parse, issue) {
         return utils.encode(key) + '=' + utils.encode(params[key]);
       }).join('&');
 
-      res.setHeader('Content-Type', 'x-www-form-urlencoded');
+      res.setHeader('Content-Type', 'application/x-www-form-urlencoded');
       res.setHeader('Cache-Control', 'no-store');
       res.setHeader('Pragma', 'no-cache');
       res.end(fue);

--- a/test/middleware/accessToken-test.js
+++ b/test/middleware/accessToken-test.js
@@ -72,7 +72,7 @@ vows.describe('accessToken').addBatch({
         assert.isNull(err);
       },
       'should set headers' : function(err, req, res) {
-        assert.equal(res._headers['Content-Type'], 'x-www-form-urlencoded');
+        assert.equal(res._headers['Content-Type'], 'application/x-www-form-urlencoded');
         assert.equal(res._headers['Cache-Control'], 'no-store');
         assert.equal(res._headers['Pragma'], 'no-cache');
       },
@@ -130,7 +130,7 @@ vows.describe('accessToken').addBatch({
         assert.isNull(err);
       },
       'should set headers' : function(err, req, res) {
-        assert.equal(res._headers['Content-Type'], 'x-www-form-urlencoded');
+        assert.equal(res._headers['Content-Type'], 'application/x-www-form-urlencoded');
         assert.equal(res._headers['Cache-Control'], 'no-store');
         assert.equal(res._headers['Pragma'], 'no-cache');
       },
@@ -188,7 +188,7 @@ vows.describe('accessToken').addBatch({
         assert.isNull(err);
       },
       'should set headers' : function(err, req, res) {
-        assert.equal(res._headers['Content-Type'], 'x-www-form-urlencoded');
+        assert.equal(res._headers['Content-Type'], 'application/x-www-form-urlencoded');
         assert.equal(res._headers['Cache-Control'], 'no-store');
         assert.equal(res._headers['Pragma'], 'no-cache');
       },
@@ -245,7 +245,7 @@ vows.describe('accessToken').addBatch({
         assert.isNull(err);
       },
       'should set headers' : function(err, req, res) {
-        assert.equal(res._headers['Content-Type'], 'x-www-form-urlencoded');
+        assert.equal(res._headers['Content-Type'], 'application/x-www-form-urlencoded');
         assert.equal(res._headers['Cache-Control'], 'no-store');
         assert.equal(res._headers['Pragma'], 'no-cache');
       },

--- a/test/middleware/errorHandler-test.js
+++ b/test/middleware/errorHandler-test.js
@@ -60,7 +60,7 @@ vows.describe('errorHandler').addBatch({
       'should set headers' : function(err, req, res) {
         assert.equal(res.statusCode, 500);
         assert.isUndefined(res._headers['WWW-Authenticate']);
-        assert.equal(res._headers['Content-Type'], 'x-www-form-urlencoded');
+        assert.equal(res._headers['Content-Type'], 'application/x-www-form-urlencoded');
       },
       'should send response' : function(err, req, res, e) {
         assert.equal(res._data, 'oauth_problem=server_error&oauth_problem_advice=something%20went%20wrong');
@@ -97,7 +97,7 @@ vows.describe('errorHandler').addBatch({
       'should set headers' : function(err, req, res) {
         assert.equal(res.statusCode, 401);
         assert.equal(res._headers['WWW-Authenticate'], 'OAuth realm="Clients",oauth_problem="token_rejected",oauth_problem_advice="something%20went%20wrong"');
-        assert.equal(res._headers['Content-Type'], 'x-www-form-urlencoded');
+        assert.equal(res._headers['Content-Type'], 'application/x-www-form-urlencoded');
       },
       'should send response' : function(err, req, res, e) {
         assert.equal(res._data, 'oauth_problem=token_rejected&oauth_problem_advice=something%20went%20wrong');
@@ -134,7 +134,7 @@ vows.describe('errorHandler').addBatch({
       'should set headers' : function(err, req, res) {
         assert.equal(res.statusCode, 400);
         assert.isUndefined(res._headers['WWW-Authenticate']);
-        assert.equal(res._headers['Content-Type'], 'x-www-form-urlencoded');
+        assert.equal(res._headers['Content-Type'], 'application/x-www-form-urlencoded');
       },
       'should send response' : function(err, req, res, e) {
         assert.equal(res._data, 'oauth_problem=parameter_absent&oauth_problem_advice=something%20went%20wrong');
@@ -171,7 +171,7 @@ vows.describe('errorHandler').addBatch({
       'should set headers' : function(err, req, res) {
         assert.equal(res.statusCode, 403);
         assert.equal(res._headers['WWW-Authenticate'], 'OAuth realm="Clients",oauth_problem="permission_denied",oauth_problem_advice="something%20went%20wrong"');
-        assert.equal(res._headers['Content-Type'], 'x-www-form-urlencoded');
+        assert.equal(res._headers['Content-Type'], 'application/x-www-form-urlencoded');
       },
       'should send response' : function(err, req, res, e) {
         assert.equal(res._data, 'oauth_problem=permission_denied&oauth_problem_advice=something%20went%20wrong');
@@ -208,7 +208,7 @@ vows.describe('errorHandler').addBatch({
       'should set headers' : function(err, req, res) {
         assert.equal(res.statusCode, 401);
         assert.equal(res._headers['WWW-Authenticate'], 'OAuth realm="http://sp.example.com/",oauth_problem="token_rejected",oauth_problem_advice="something%20went%20wrong"');
-        assert.equal(res._headers['Content-Type'], 'x-www-form-urlencoded');
+        assert.equal(res._headers['Content-Type'], 'application/x-www-form-urlencoded');
       },
       'should send response' : function(err, req, res, e) {
         assert.equal(res._data, 'oauth_problem=token_rejected&oauth_problem_advice=something%20went%20wrong');

--- a/test/middleware/requestToken-test.js
+++ b/test/middleware/requestToken-test.js
@@ -62,7 +62,7 @@ vows.describe('requestToken').addBatch({
         assert.isNull(err);
       },
       'should set headers' : function(err, req, res) {
-        assert.equal(res._headers['Content-Type'], 'x-www-form-urlencoded');
+        assert.equal(res._headers['Content-Type'], 'application/x-www-form-urlencoded');
         assert.equal(res._headers['Cache-Control'], 'no-store');
         assert.equal(res._headers['Pragma'], 'no-cache');
       },
@@ -109,7 +109,7 @@ vows.describe('requestToken').addBatch({
         assert.isNull(err);
       },
       'should set headers' : function(err, req, res) {
-        assert.equal(res._headers['Content-Type'], 'x-www-form-urlencoded');
+        assert.equal(res._headers['Content-Type'], 'application/x-www-form-urlencoded');
         assert.equal(res._headers['Cache-Control'], 'no-store');
         assert.equal(res._headers['Pragma'], 'no-cache');
       },
@@ -165,7 +165,7 @@ vows.describe('requestToken').addBatch({
         assert.isNull(err);
       },
       'should set headers' : function(err, req, res) {
-        assert.equal(res._headers['Content-Type'], 'x-www-form-urlencoded');
+        assert.equal(res._headers['Content-Type'], 'application/x-www-form-urlencoded');
         assert.equal(res._headers['Cache-Control'], 'no-store');
         assert.equal(res._headers['Pragma'], 'no-cache');
       },
@@ -212,7 +212,7 @@ vows.describe('requestToken').addBatch({
         assert.isNull(err);
       },
       'should set headers' : function(err, req, res) {
-        assert.equal(res._headers['Content-Type'], 'x-www-form-urlencoded');
+        assert.equal(res._headers['Content-Type'], 'application/x-www-form-urlencoded');
         assert.equal(res._headers['Cache-Control'], 'no-store');
         assert.equal(res._headers['Pragma'], 'no-cache');
       },


### PR DESCRIPTION
Hi,
I changed content-type 'x-www-form-urlencoded' to valid content-type 'application/x-www-form-urlencoded'

Content type for response should be 'application/x-www-form-urlencoded'. 
Some client libraries are using this to check the response format.

This is most likely a breaking change for most users of the library so it may be better to include this in a 0.2.0 release or to add it as an option to createServer()
